### PR TITLE
Fix scenario validation nil checks

### DIFF
--- a/scoreboard/scoreboard.go
+++ b/scoreboard/scoreboard.go
@@ -285,17 +285,17 @@ func (s *Scenario) Validate() error {
 			return err
 		}
 	}
-	for k := range s.In {
+	for k := range s.Out {
 		if err := k.Validate(); err != nil {
 			return err
 		}
 	}
-	if s.GenSync == nil {
+	if s.GenSync != nil {
 		if err := s.GenSync.Validate(); err != nil {
 			return err
 		}
 	}
-	if s.GenStream == nil {
+	if s.GenStream != nil {
 		if err := s.GenStream.Validate(); err != nil {
 			return err
 		}

--- a/scoreboard/scoreboard_test.go
+++ b/scoreboard/scoreboard_test.go
@@ -76,3 +76,40 @@ func TestTriState(t *testing.T) {
 		}
 	})
 }
+
+func TestScenarioValidate(t *testing.T) {
+	t.Run("Valid", func(t *testing.T) {
+		sc := Scenario{
+			In: map[Modality]ModalCapability{
+				ModalityText: {},
+			},
+			Out: map[Modality]ModalCapability{
+				ModalityText: {},
+			},
+			GenSync: &Functionality{},
+		}
+		if err := sc.Validate(); err != nil {
+			t.Fatalf("Scenario.Validate() returned error: %v", err)
+		}
+	})
+
+	t.Run("InvalidModality", func(t *testing.T) {
+		sc := Scenario{
+			In: map[Modality]ModalCapability{
+				Modality("unsupported"): {},
+			},
+		}
+		if err := sc.Validate(); err == nil {
+			t.Fatal("Scenario.Validate() returned nil error")
+		}
+	})
+
+	t.Run("InvalidFunctionality", func(t *testing.T) {
+		sc := Scenario{
+			GenStream: &Functionality{Tools: TriState(42)},
+		}
+		if err := sc.Validate(); err == nil {
+			t.Fatal("Scenario.Validate() returned nil error")
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- ensure Scenario.Validate checks both input and output modalities and skips nil functionality values
- add unit tests covering valid and invalid scenario validation cases

## Testing
- go test ./scoreboard -count=1


------
https://chatgpt.com/codex/tasks/task_e_68f175ff442c832398c239337b135f3f